### PR TITLE
1.1.14 September 2021 Release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -184,7 +184,7 @@
 	],
 	"require": {
 		"altis/browser-security": "^1.1.0",
-		"altis/workflow": "^7.0.0",
+		"altis/workflow": "^8.0.0",
 		"cmb2/cmb2": "^v2.7.0",
 		"humanmade/amf-unsplash": "^0.1.1",
 		"humanmade/gaussholder": "^1.1.3",

--- a/composer.json
+++ b/composer.json
@@ -237,6 +237,6 @@
 		}
 	},
 	"require-dev": {
-		"altis/local-server": "^7.0"
+		"altis/local-server": "^8.0"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -211,7 +211,7 @@
 		"wpackagist-plugin/amazon-s3-and-cloudfront": "^2.4.4",
 		"wpackagist-plugin/glotpress": "^2.3.1",
 		"wpackagist-plugin/google-analyticator": "^6.5.5",
-		"wpackagist-plugin/gutenberg": "^10.0.2",
+		"wpackagist-plugin/gutenberg": "^11.1.0",
 		"wpackagist-plugin/jetpack": "^9.2.0",
 		"wpackagist-plugin/ninja-forms": "^3.4.30",
 		"wpackagist-plugin/organize-series": "^2.5.13",

--- a/composer.json
+++ b/composer.json
@@ -212,7 +212,7 @@
 		"wpackagist-plugin/glotpress": "^2.3.1",
 		"wpackagist-plugin/google-analyticator": "^6.5.5",
 		"wpackagist-plugin/gutenberg": "^11.1.0",
-		"wpackagist-plugin/jetpack": "^9.2.0",
+		"wpackagist-plugin/jetpack": "^10.0",
 		"wpackagist-plugin/ninja-forms": "^3.4.30",
 		"wpackagist-plugin/organize-series": "^2.5.13",
 		"wpackagist-plugin/p3-profiler": "^1.5.3",

--- a/composer.json
+++ b/composer.json
@@ -186,7 +186,7 @@
 		"altis/browser-security": "^1.1.0",
 		"altis/workflow": "^8.0.0",
 		"cmb2/cmb2": "^v2.7.0",
-		"humanmade/amf-unsplash": "^0.1.1",
+		"humanmade/amf-unsplash": "^0.2.0",
 		"humanmade/gaussholder": "^1.1.3",
 		"humanmade/hm-redirects": "^0.5.2",
 		"humanmade/meta-tags": "^0.1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -1593,15 +1593,15 @@
         },
         {
             "name": "wpackagist-theme/twentynineteen",
-            "version": "2.0",
+            "version": "2.1",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentynineteen/",
-                "reference": "2.0"
+                "reference": "2.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentynineteen.2.0.zip"
+                "url": "https://downloads.wordpress.org/theme/twentynineteen.2.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1413,18 +1413,18 @@
         },
         {
             "name": "wpackagist-plugin/organize-series",
-            "version": "2.6.0",
+            "version": "2.6.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/organize-series/",
-                "reference": "tags/2.6.0"
+                "reference": "tags/2.6.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/organize-series.2.6.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/organize-series.2.6.2.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/organize-series/"

--- a/composer.lock
+++ b/composer.lock
@@ -1359,15 +1359,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "11.2.0",
+            "version": "11.4.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/11.2.0"
+                "reference": "tags/11.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.2.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.4.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "113a16e09b62eaed912a283197bc911a",
+    "content-hash": "d414d65044ad09b9c5f708c1ad29ce26",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -1354,15 +1354,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "10.7.3",
+            "version": "11.1.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/10.7.3"
+                "reference": "tags/11.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.10.7.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.1.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1611,15 +1611,15 @@
         },
         {
             "name": "wpackagist-theme/twentyseventeen",
-            "version": "2.7",
+            "version": "2.8",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentyseventeen/",
-                "reference": "2.7"
+                "reference": "2.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentyseventeen.2.7.zip"
+                "url": "https://downloads.wordpress.org/theme/twentyseventeen.2.8.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1354,15 +1354,15 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "11.1.0",
+            "version": "11.2.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/11.1.0"
+                "reference": "tags/11.2.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.1.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.2.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1385,15 +1385,15 @@
         },
         {
             "name": "wpackagist-plugin/ninja-forms",
-            "version": "3.5.4",
+            "version": "3.5.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.5.4"
+                "reference": "tags/3.5.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e658c75e4bce5e62e2d13b20bae810ab",
+    "content-hash": "6cc1ed67119f88b2f4363c57b6239eed",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -268,20 +268,20 @@
         },
         {
             "name": "humanmade/amf-unsplash",
-            "version": "0.1.1",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/amf-unsplash.git",
-                "reference": "d0965f551338fcddef60c26ee51ceb957392beb4"
+                "reference": "779c370fd6e936432ca2576a1081851712d224c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/amf-unsplash/zipball/d0965f551338fcddef60c26ee51ceb957392beb4",
-                "reference": "d0965f551338fcddef60c26ee51ceb957392beb4",
+                "url": "https://api.github.com/repos/humanmade/amf-unsplash/zipball/779c370fd6e936432ca2576a1081851712d224c8",
+                "reference": "779c370fd6e936432ca2576a1081851712d224c8",
                 "shasum": ""
             },
             "require": {
-                "humanmade/asset-manager-framework": "~0.6",
+                "humanmade/asset-manager-framework": "^0.12",
                 "php": ">=7.2"
             },
             "type": "wordpress-plugin",
@@ -298,22 +298,22 @@
             "description": "Bring Unsplash directly into your WordPress media library.",
             "support": {
                 "issues": "https://github.com/humanmade/amf-unsplash/issues",
-                "source": "https://github.com/humanmade/amf-unsplash/tree/master"
+                "source": "https://github.com/humanmade/amf-unsplash/tree/0.2.0"
             },
-            "time": "2020-04-18T14:11:32+00:00"
+            "time": "2021-08-26T15:01:47+00:00"
         },
         {
             "name": "humanmade/asset-manager-framework",
-            "version": "0.8.1",
+            "version": "0.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/asset-manager-framework.git",
-                "reference": "342fd5d83845cae9cbf5c7516477b4d8a0b50516"
+                "reference": "58d08f19e55d67a4fc8b9b0351a00058f4cb482c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/asset-manager-framework/zipball/342fd5d83845cae9cbf5c7516477b4d8a0b50516",
-                "reference": "342fd5d83845cae9cbf5c7516477b4d8a0b50516",
+                "url": "https://api.github.com/repos/humanmade/asset-manager-framework/zipball/58d08f19e55d67a4fc8b9b0351a00058f4cb482c",
+                "reference": "58d08f19e55d67a4fc8b9b0351a00058f4cb482c",
                 "shasum": ""
             },
             "require": {
@@ -327,6 +327,11 @@
                 "wp-coding-standards/wpcs": "~2.2.0"
             },
             "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "AssetManagerFramework\\": "inc/"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
@@ -341,9 +346,9 @@
             "homepage": "https://github.com/humanmade/asset-manager-framework/",
             "support": {
                 "issues": "https://github.com/humanmade/asset-manager-framework/issues",
-                "source": "https://github.com/humanmade/asset-manager-framework/tree/0.8.1"
+                "source": "https://github.com/humanmade/asset-manager-framework/tree/0.12.5"
             },
-            "time": "2020-09-30T12:39:15+00:00"
+            "time": "2021-08-05T08:37:01+00:00"
         },
         {
             "name": "humanmade/gaussholder",

--- a/composer.lock
+++ b/composer.lock
@@ -1657,22 +1657,22 @@
     "packages-dev": [
         {
             "name": "altis/local-server",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-local-server.git",
-                "reference": "5271af93dc37fbc8c6c7b49b75fd6456553b0b60"
+                "reference": "430e59309641420a10e2597da50d2b8c2bf703a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/5271af93dc37fbc8c6c7b49b75fd6456553b0b60",
-                "reference": "5271af93dc37fbc8c6c7b49b75fd6456553b0b60",
+                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/430e59309641420a10e2597da50d2b8c2bf703a2",
+                "reference": "430e59309641420a10e2597da50d2b8c2bf703a2",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0",
                 "php": ">=7.1",
-                "symfony/yaml": "^5.2"
+                "symfony/yaml": "~5.3.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -1701,9 +1701,9 @@
             "description": "Local Server module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-local-server/issues",
-                "source": "https://github.com/humanmade/altis-local-server/tree/7.0.0"
+                "source": "https://github.com/humanmade/altis-local-server/tree/7.0.1"
             },
-            "time": "2021-04-14T09:22:06+00:00"
+            "time": "2021-06-09T14:59:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1774,16 +1774,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -1795,7 +1795,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1833,7 +1833,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -1849,20 +1849,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.2.7",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5"
+                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
+                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
                 "shasum": ""
             },
             "require": {
@@ -1908,7 +1908,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.2.7"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -1924,7 +1924,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-29T20:47:09+00:00"
+            "time": "2021-05-26T17:43:10+00:00"
         }
     ],
     "aliases": [],
@@ -1936,5 +1936,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1395,18 +1395,18 @@
         },
         {
             "name": "wpackagist-plugin/ninja-forms",
-            "version": "3.5.7",
+            "version": "3.5.9",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.5.7"
+                "reference": "tags/3.5.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.9.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/ninja-forms/"

--- a/composer.lock
+++ b/composer.lock
@@ -1300,15 +1300,15 @@
         },
         {
             "name": "wpackagist-plugin/amazon-s3-and-cloudfront",
-            "version": "2.5.3",
+            "version": "2.5.5",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/amazon-s3-and-cloudfront/",
-                "reference": "tags/2.5.3"
+                "reference": "tags/2.5.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.2.5.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.2.5.5.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1408,15 +1408,15 @@
         },
         {
             "name": "wpackagist-plugin/organize-series",
-            "version": "2.5.13",
+            "version": "2.6.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/organize-series/",
-                "reference": "tags/2.5.13"
+                "reference": "tags/2.6.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/organize-series.2.5.13.zip"
+                "url": "https://downloads.wordpress.org/plugin/organize-series.2.6.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -268,16 +268,16 @@
         },
         {
             "name": "humanmade/amf-unsplash",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/amf-unsplash.git",
-                "reference": "779c370fd6e936432ca2576a1081851712d224c8"
+                "reference": "97bcdc10c9ce3d9a58c1dafe941befa59473917a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/amf-unsplash/zipball/779c370fd6e936432ca2576a1081851712d224c8",
-                "reference": "779c370fd6e936432ca2576a1081851712d224c8",
+                "url": "https://api.github.com/repos/humanmade/amf-unsplash/zipball/97bcdc10c9ce3d9a58c1dafe941befa59473917a",
+                "reference": "97bcdc10c9ce3d9a58c1dafe941befa59473917a",
                 "shasum": ""
             },
             "require": {
@@ -298,9 +298,9 @@
             "description": "Bring Unsplash directly into your WordPress media library.",
             "support": {
                 "issues": "https://github.com/humanmade/amf-unsplash/issues",
-                "source": "https://github.com/humanmade/amf-unsplash/tree/0.2.0"
+                "source": "https://github.com/humanmade/amf-unsplash/tree/0.2.1"
             },
-            "time": "2021-08-26T15:01:47+00:00"
+            "time": "2021-08-31T10:04:17+00:00"
         },
         {
             "name": "humanmade/asset-manager-framework",

--- a/composer.lock
+++ b/composer.lock
@@ -1377,18 +1377,18 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "10.0",
+            "version": "10.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/10.0"
+                "reference": "tags/10.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.10.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.10.1.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/jetpack/"

--- a/composer.lock
+++ b/composer.lock
@@ -1647,15 +1647,15 @@
         },
         {
             "name": "wpackagist-theme/twentytwentyone",
-            "version": "1.3",
+            "version": "1.4",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentytwentyone/",
-                "reference": "1.3"
+                "reference": "1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentytwentyone.1.3.zip"
+                "url": "https://downloads.wordpress.org/theme/twentytwentyone.1.4.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1359,18 +1359,18 @@
         },
         {
             "name": "wpackagist-plugin/gutenberg",
-            "version": "11.4.0",
+            "version": "11.4.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/11.4.0"
+                "reference": "tags/11.4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.4.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.11.4.1.zip"
             },
             "require": {
-                "composer/installers": "~1.0"
+                "composer/installers": "~1.0 || ~2.0"
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/gutenberg/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d414d65044ad09b9c5f708c1ad29ce26",
+    "content-hash": "e658c75e4bce5e62e2d13b20bae810ab",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -1372,15 +1372,15 @@
         },
         {
             "name": "wpackagist-plugin/jetpack",
-            "version": "9.8",
+            "version": "10.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/jetpack/",
-                "reference": "tags/9.8"
+                "reference": "tags/10.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/jetpack.9.8.zip"
+                "url": "https://downloads.wordpress.org/plugin/jetpack.10.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1720,16 +1720,16 @@
     "packages-dev": [
         {
             "name": "altis/local-server",
-            "version": "8.0.0",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-local-server.git",
-                "reference": "b8274abd696b76ba3326e4f0b259c56bbe6f5700"
+                "reference": "6899e23f252065cad70fd2b98665d25edfca09b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/b8274abd696b76ba3326e4f0b259c56bbe6f5700",
-                "reference": "b8274abd696b76ba3326e4f0b259c56bbe6f5700",
+                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/6899e23f252065cad70fd2b98665d25edfca09b1",
+                "reference": "6899e23f252065cad70fd2b98665d25edfca09b1",
                 "shasum": ""
             },
             "require": {
@@ -1764,9 +1764,9 @@
             "description": "Local Server module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-local-server/issues",
-                "source": "https://github.com/humanmade/altis-local-server/tree/8.0.0"
+                "source": "https://github.com/humanmade/altis-local-server/tree/8.0.1"
             },
-            "time": "2021-07-30T12:32:05+00:00"
+            "time": "2021-08-04T17:16:46+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c55312d39cdcaa3ed7b38631bb53694a",
+    "content-hash": "113a16e09b62eaed912a283197bc911a",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -576,28 +576,30 @@
         },
         {
             "name": "humanmade/two-factor",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/two-factor.git",
-                "reference": "7b4cce30d48b7c90591fe4991dd20ea7f92eb7ac"
+                "reference": "93fd2b2aa2da9c0da2b8a71c1ba72f1a42b8fafb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/two-factor/zipball/7b4cce30d48b7c90591fe4991dd20ea7f92eb7ac",
-                "reference": "7b4cce30d48b7c90591fe4991dd20ea7f92eb7ac",
+                "url": "https://api.github.com/repos/humanmade/two-factor/zipball/93fd2b2aa2da9c0da2b8a71c1ba72f1a42b8fafb",
+                "reference": "93fd2b2aa2da9c0da2b8a71c1ba72f1a42b8fafb",
                 "shasum": ""
             },
             "require-dev": {
-                "php-coveralls/php-coveralls": "^1.0"
+                "php-coveralls/php-coveralls": "^1.0",
+                "wp-coding-standards/wpcs": "^1.0",
+                "xwp/wp-dev-lib": "dev-master"
             },
             "type": "wordpress-plugin",
             "notification-url": "https://packagist.org/downloads/",
             "description": "Two-Factor Authentication for WordPress.",
             "support": {
-                "source": "https://github.com/humanmade/two-factor/tree/0.2"
+                "source": "https://github.com/humanmade/two-factor/tree/0.2.1"
             },
-            "time": "2018-09-17T23:01:41+00:00"
+            "time": "2021-07-21T17:54:25+00:00"
         },
         {
             "name": "humanmade/wordpress-importer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38f9e072795f7f8e66995dd00623e30c",
+    "content-hash": "c55312d39cdcaa3ed7b38631bb53694a",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -1718,22 +1718,22 @@
     "packages-dev": [
         {
             "name": "altis/local-server",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-local-server.git",
-                "reference": "430e59309641420a10e2597da50d2b8c2bf703a2"
+                "reference": "b8274abd696b76ba3326e4f0b259c56bbe6f5700"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/430e59309641420a10e2597da50d2b8c2bf703a2",
-                "reference": "430e59309641420a10e2597da50d2b8c2bf703a2",
+                "url": "https://api.github.com/repos/humanmade/altis-local-server/zipball/b8274abd696b76ba3326e4f0b259c56bbe6f5700",
+                "reference": "b8274abd696b76ba3326e4f0b259c56bbe6f5700",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0",
                 "php": ">=7.1",
-                "symfony/yaml": "~5.3.0"
+                "symfony/yaml": "~5.3.6"
             },
             "type": "composer-plugin",
             "extra": {
@@ -1762,9 +1762,9 @@
             "description": "Local Server module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-local-server/issues",
-                "source": "https://github.com/humanmade/altis-local-server/tree/7.0.1"
+                "source": "https://github.com/humanmade/altis-local-server/tree/8.0.0"
             },
-            "time": "2021-06-09T14:59:46+00:00"
+            "time": "2021-07-30T12:32:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1914,16 +1914,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.3.0",
+            "version": "v5.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11"
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
-                "reference": "3bbcf262fceb3d8f48175302e6ba0ac96e3a5a11",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
+                "reference": "4500fe63dc9c6ffc32d3b1cb0448c329f9c814b7",
                 "shasum": ""
             },
             "require": {
@@ -1969,7 +1969,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.3.0"
+                "source": "https://github.com/symfony/yaml/tree/v5.3.6"
             },
             "funding": [
                 {
@@ -1985,7 +1985,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-07-29T06:20:01+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1629,15 +1629,15 @@
         },
         {
             "name": "wpackagist-theme/twentytwenty",
-            "version": "1.7",
+            "version": "1.8",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentytwenty/",
-                "reference": "1.7"
+                "reference": "1.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentytwenty.1.7.zip"
+                "url": "https://downloads.wordpress.org/theme/twentytwenty.1.8.zip"
             },
             "require": {
                 "composer/installers": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -51,16 +51,16 @@
         },
         {
             "name": "altis/workflow",
-            "version": "8.0.0",
+            "version": "8.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-workflow.git",
-                "reference": "4d95e5fc87c5e11d16ccdea10e9108a25858aa63"
+                "reference": "638cd4028e776b37421c9390de2d8e18d3ac57f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/4d95e5fc87c5e11d16ccdea10e9108a25858aa63",
-                "reference": "4d95e5fc87c5e11d16ccdea10e9108a25858aa63",
+                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/638cd4028e776b37421c9390de2d8e18d3ac57f3",
+                "reference": "638cd4028e776b37421c9390de2d8e18d3ac57f3",
                 "shasum": ""
             },
             "require": {
@@ -102,9 +102,9 @@
             "description": "Workflow module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-workflow/issues",
-                "source": "https://github.com/humanmade/altis-workflow/tree/8.0.0"
+                "source": "https://github.com/humanmade/altis-workflow/tree/8.0.1"
             },
-            "time": "2021-07-22T10:21:03+00:00"
+            "time": "2021-08-06T13:03:33+00:00"
         },
         {
             "name": "cmb2/cmb2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07b26cdabff03e8b761fe6b791565bf4",
+    "content-hash": "38f9e072795f7f8e66995dd00623e30c",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -51,29 +51,31 @@
         },
         {
             "name": "altis/workflow",
-            "version": "7.0.0",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-workflow.git",
-                "reference": "fdacaecf0cd81b8ba3ac5c00cf12b6875778fcb3"
+                "reference": "4d95e5fc87c5e11d16ccdea10e9108a25858aa63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/fdacaecf0cd81b8ba3ac5c00cf12b6875778fcb3",
-                "reference": "fdacaecf0cd81b8ba3ac5c00cf12b6875778fcb3",
+                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/4d95e5fc87c5e11d16ccdea10e9108a25858aa63",
+                "reference": "4d95e5fc87c5e11d16ccdea10e9108a25858aa63",
                 "shasum": ""
             },
             "require": {
-                "humanmade/publication-checklist": "~0.2.0",
-                "humanmade/workflows": "~0.3.11",
-                "php": ">=7.1"
+                "humanmade/publication-checklist": "~0.3.0",
+                "humanmade/workflows": "~0.3.17",
+                "php": ">=7.1",
+                "yoast/duplicate-post": "~4.1.2"
             },
             "type": "package",
             "extra": {
                 "altis": {
                     "install-overrides": [
                         "humanmade/workflows",
-                        "humanmade/publication-checklist"
+                        "humanmade/publication-checklist",
+                        "yoast/duplicate-post"
                     ]
                 }
             },
@@ -83,7 +85,8 @@
                 ],
                 "files": [
                     "inc/namespace.php",
-                    "inc/notifications/namespace.php"
+                    "inc/notifications/namespace.php",
+                    "inc/clone-amend/namespace.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -99,9 +102,9 @@
             "description": "Workflow module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-workflow/issues",
-                "source": "https://github.com/humanmade/altis-workflow/tree/7.0.0"
+                "source": "https://github.com/humanmade/altis-workflow/tree/8.0.0"
             },
-            "time": "2021-02-01T11:41:55+00:00"
+            "time": "2021-07-22T10:21:03+00:00"
         },
         {
             "name": "cmb2/cmb2",
@@ -538,16 +541,16 @@
         },
         {
             "name": "humanmade/publication-checklist",
-            "version": "0.2.2",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/publication-checklist.git",
-                "reference": "f82cb5933595502a0b7a004a758778d6b510c409"
+                "reference": "b5a63a7884a0717675d2e4536b7419ea22d9fc9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/f82cb5933595502a0b7a004a758778d6b510c409",
-                "reference": "f82cb5933595502a0b7a004a758778d6b510c409",
+                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/b5a63a7884a0717675d2e4536b7419ea22d9fc9d",
+                "reference": "b5a63a7884a0717675d2e4536b7419ea22d9fc9d",
                 "shasum": ""
             },
             "require": {
@@ -567,9 +570,9 @@
             "description": "Run checks and enforce conditions before posts are published.",
             "support": {
                 "issues": "https://github.com/humanmade/publication-checklist/issues",
-                "source": "https://github.com/humanmade/publication-checklist/tree/0.2.2--branch"
+                "source": "https://github.com/humanmade/publication-checklist/tree/0.3.0"
             },
-            "time": "2020-09-08T16:13:47+00:00"
+            "time": "2021-06-21T16:52:06+00:00"
         },
         {
             "name": "humanmade/two-factor",
@@ -656,16 +659,16 @@
         },
         {
             "name": "humanmade/workflows",
-            "version": "0.3.16",
+            "version": "0.3.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/Workflows.git",
-                "reference": "fce0cf62cd15a4da0761f67a97e034747bf2b0b4"
+                "reference": "96f8d98f9eb1650388a42a0c5de84a8fdc7ff112"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/Workflows/zipball/fce0cf62cd15a4da0761f67a97e034747bf2b0b4",
-                "reference": "fce0cf62cd15a4da0761f67a97e034747bf2b0b4",
+                "url": "https://api.github.com/repos/humanmade/Workflows/zipball/96f8d98f9eb1650388a42a0c5de84a8fdc7ff112",
+                "reference": "96f8d98f9eb1650388a42a0c5de84a8fdc7ff112",
                 "shasum": ""
             },
             "require": {
@@ -688,9 +691,9 @@
             "description": "Workflow management for WordPress, an extensible event and notification system.",
             "support": {
                 "issues": "https://github.com/humanmade/Workflows/issues",
-                "source": "https://github.com/humanmade/Workflows/tree/0.3.16"
+                "source": "https://github.com/humanmade/Workflows/tree/0.3.17"
             },
-            "time": "2021-04-30T18:38:37+00:00"
+            "time": "2021-06-02T09:45:40+00:00"
         },
         {
             "name": "humanmade/wp-seo",
@@ -1652,6 +1655,64 @@
             },
             "type": "wordpress-theme",
             "homepage": "https://wordpress.org/themes/twentytwentyone/"
+        },
+        {
+            "name": "yoast/duplicate-post",
+            "version": "4.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast-dist/duplicate-post.git",
+                "reference": "92fd35b2a494555166470e0906a3463d0b897687"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast-dist/duplicate-post/zipball/92fd35b2a494555166470e0906a3463d0b897687",
+                "reference": "92fd35b2a494555166470e0906a3463d0b897687",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "^1.9.0",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "automattic/vipwpcs": "^2.0",
+                "brain/monkey": "^2.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "phpunit/phpunit": "^5.7",
+                "wp-coding-standards/wpcs": "^2.1"
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Enrico Battocchi & Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                }
+            ],
+            "description": "The go-to tool for cloning posts and pages, including the powerful Rewrite & Republish feature.",
+            "homepage": "https://wordpress.org/plugins/duplicate-post/",
+            "keywords": [
+                "clone",
+                "copy",
+                "post",
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://wordpress.org/support/plugin/duplicate-post",
+                "issues": "https://github.com/Yoast/duplicate-post/issues",
+                "source": "https://github.com/Yoast/duplicate-post"
+            },
+            "time": "2021-05-26T09:13:56+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -1385,15 +1385,15 @@
         },
         {
             "name": "wpackagist-plugin/ninja-forms",
-            "version": "3.5.6",
+            "version": "3.5.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.5.6"
+                "reference": "tags/3.5.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.5.7.zip"
             },
             "require": {
                 "composer/installers": "~1.0"


### PR DESCRIPTION
## Altis Updates
* Bump altis/local-server from 7.0.0 to 8.0.1 
  * #97 
  * #116 
  * #120
* #110 
* Bump altis/workflow from 7.0.0 to 8.0.1 
  * #117 
  * #122  

## Plugin Updates
* Bump wpackagist-plugin/gutenberg from 10.7.3 to 11.4.1 
  * #108 
  * #118 
  * #127 
  * #129
* Bump wpackagist-plugin/ninja-forms from 3.5.4 to 3.5.9 
  * #102 
  * #103 
  * #131
* #106  
* Bump wpackagist-plugin/jetpack from 9.8 to 10.1 
  * #119 
  * #132
* Bump wpackagist-plugin/organize-series from 2.5.13 to 2.6.2 
  * #124 
  * #130
* Bump humanmade/amf-unsplash from 0.1.1 to 0.2.1 
  * #125 
  * #126

## Theme Updates
* #111 
* #112 
* #113 
* #114   