### PR TITLE
add a path repository & jz-222

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ readme.html
 
 # Don't ignore packages
 !packages/*
-!/packages/jz-222/index.php
+!packages/jz-222/index.php
+packages/*/.git
 
 # ignore random other shit
 audio/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ server-config.php
 /index.php
 readme.html
 
+# Don't ignore packages
+!packages/*
+!/packages/jz-222/index.php
+
 # ignore random other shit
 audio/
 images/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/jz-222"]
+	path = packages/jz-222
+	url = git@github.com:jazzseequence/jz-222.git

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
 			"url": "https://wpackagist.org"
 		},
 		{
+			"type": "path",
+			"url": "./packages",
+			"symlinks": true
+		},
+		{
 			"type": "package",
 			"package": {
 				"name": "cmb2/cmb2",
@@ -76,6 +81,10 @@
 		{
 			"type": "vcs",
 			"url": "git@github.com:jazzsequence/recipe-box.git"
+		},
+		{
+			"type": "vcs",
+			"url": "git@github.com:jazzsequence/jz-222.git"
 		},
 		{
 			"type": "package",
@@ -174,6 +183,7 @@
 		"jazzsequence/cat-signal": "^1.1.3",
 		"jazzsequence/dashboard-changelog": "^1.1.0",
 		"jazzsequence/games-collector": "1.3.4",
+		"jazzsequence/jz-222": "dev-main",
 		"jazzsequence/notifications": "^1.1.3",
 		"jazzsequence/recipe-box": "^0.3",
 		"jazzsequence/releases": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4a574082145359381088d1250079cb6",
+    "content-hash": "89abff7eaf232b84664104b31090aa63",
     "packages": [
         {
             "name": "altis/browser-security",
@@ -876,6 +876,38 @@
                 "reference": "tags/1.3.4"
             },
             "type": "wordpress-plugin"
+        },
+        {
+            "name": "jazzsequence/jz-222",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jazzsequence/jz-222.git",
+                "reference": "ea4de73b220b7cd72987066513b8135682a4865e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jazzsequence/jz-222/zipball/ea4de73b220b7cd72987066513b8135682a4865e",
+                "reference": "ea4de73b220b7cd72987066513b8135682a4865e",
+                "shasum": ""
+            },
+            "default-branch": true,
+            "type": "wordpress-theme",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Reynolds",
+                    "email": "chris@jazzsequence.com"
+                }
+            ],
+            "description": "Experimental child theme for Twenty Twenty-Two",
+            "support": {
+                "source": "https://github.com/jazzsequence/jz-222/tree/main",
+                "issues": "https://github.com/jazzsequence/jz-222/issues"
+            },
+            "time": "2022-01-28T22:32:27+00:00"
         },
         {
             "name": "jazzsequence/notifications",
@@ -2236,6 +2268,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "humanmade/wordpress-importer": 20,
+        "jazzsequence/jz-222": 20,
         "markjaquith/gifdrop": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
use a composer path repository to handle installing and controlling jz-222

add it as a git submodule so I can edit it from inside jazzsequence.com repo