### PR TITLE
Don't overwrite index.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -234,7 +234,13 @@
 		}
 	},
 	"scripts": {
-		"pre-update-cmd": "cp wp-config.php wp-config.php.bak",
-		"post-update-cmd": "mv wp-config.php.bak wp-config.php"
+		"pre-update-cmd": [
+			"cp wp-config.php wp-config.php.bak",
+			"cp index.php index.php.tmp"
+		],
+		"post-update-cmd": [
+			"mv wp-config.php.bak wp-config.php",
+			"mv index.php.tmp index.php"
+		]
 	}
 }


### PR DESCRIPTION
Altis has update scripts that also overwrite the index.php to point to `/wordpress`. We don't want to do that because we're not deploying /wordpress.
