### PR TITLE
Release 1.5.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"sevVerDescription": "Updates and patches should always be x.x.Y patch updates. WordPress updates or major feature additions (like new plugins or themes) should be x.Y.x minor updates. Major site updates should be Y.x.x major updates."
 }

--- a/wp-content/themes/artbox/index.php
+++ b/wp-content/themes/artbox/index.php
@@ -25,8 +25,8 @@ get_header();
 
 <?php endwhile;?>
 	<div class="navigation">
-		<div class="nav-previous alignright"><?php previous_posts_link( 'Older Entries >>' ); ?></div>
-		<div class="nav-next alignleft"><?php next_posts_link( '<< Recent Entries' ); ?></div>
+		<div class="nav-previous alignleft"><?php previous_posts_link( '<< Recent Entries >>' ); ?></div>
+		<div class="nav-next alignright"><?php next_posts_link( '<< Older Entries' ); ?></div>
 	</div>
 <?php else: ?>
 	<p><?php _e('Sorry, no posts matched your criteria.'); ?></p>


### PR DESCRIPTION
# Update old/new post labels in aRTbOX pagination

This update fixes a minor issue in the labels for old/new post pagination on the kidsblog