### PR TITLE
remove the --delete param

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           fi
       - name: Deploy to Digital Ocean
         run: |
-          rsync -avz --progress --delete \
+          rsync -avz --progress \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.github' \

--- a/.github/workflows/dry-run-deploy.yml
+++ b/.github/workflows/dry-run-deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Dry Run Rsync
         run: |
-          rsync -avz --dry-run --delete \
+          rsync -avz --dry-run \
             --exclude='node_modules' \
             --exclude='.git' \
             --exclude='.github' \


### PR DESCRIPTION
this means that existing files will be left alone and would need to be manually deleted if we ran into problems or renamed things.

this is safer and easier than complex filters or excludes. i could manage an excludes file/workflow in the future but for now i just want it to work. I also think (but am not sure) that this is what deployhq is doing anyway.