### PR TITLE
Add 2025 theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,8 @@
 		"wpackagist-theme/twentytwenty": "*",
 		"wpackagist-theme/twentytwentyone": "*",
 		"wpackagist-theme/twentytwentythree": "*",
-		"wpackagist-theme/twentytwentytwo": "*"
+		"wpackagist-theme/twentytwentytwo": "*",
+		"wpackagist-theme/twentytwentyfive": "*"
 	},
 	"replace":{
 		"johnpbloch/wordpress": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d5d12e7cded522fed651692fe6d50f8",
+    "content-hash": "b7a88ef9acfe5321e66d7f41d956af49",
     "packages": [
         {
             "name": "10up/simple-local-avatars",
@@ -2127,6 +2127,24 @@
             },
             "type": "wordpress-theme",
             "homepage": "https://wordpress.org/themes/twentytwenty/"
+        },
+        {
+            "name": "wpackagist-theme/twentytwentyfive",
+            "version": "1.2",
+            "source": {
+                "type": "svn",
+                "url": "https://themes.svn.wordpress.org/twentytwentyfive/",
+                "reference": "1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/theme/twentytwentyfive.1.2.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-theme",
+            "homepage": "https://wordpress.org/themes/twentytwentyfive/"
         },
         {
             "name": "wpackagist-theme/twentytwentyone",

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"sevVerDescription": "Updates and patches should always be x.x.Y patch updates. WordPress updates or major feature additions (like new plugins or themes) should be x.Y.x minor updates. Major site updates should be Y.x.x major updates."
 }


### PR DESCRIPTION
The TwentyTwentyFive theme was installed (from a WordPress update) but never added to Composer. Adding it to Composer so updates can be managed normally (via Composer).