### PR TITLE
Ninja forms and Composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -228,16 +228,23 @@
 		}
 	},
 	"scripts": {
-		"pre-update-cmd": [
+		"backup-files": [
 			"if [ -f wp-config.php ]; then cp wp-config.php wp-config.php.bak; fi",
-			"if [ -f index.php ]; then cp index.php index.php.tmp; fi"
+			"if [ -f index.php ]; then cp index.php index.php.bak; fi"
+		],
+		"restore-backup-files": [
+			"if [ -f wp-config.php.bak ]; then mv wp-config.php.bak wp-config.php; fi",
+			"if [ -f index.php.bak ]; then mv index.php.bak index.php; fi",
+			"rm .build-script"
+		],
+		"pre-update-cmd": [
+			"@backup-files"
 		],
 		"post-update-cmd": [
-			"if [ -f wp-config.php.bak ]; then mv wp-config.php.bak wp-config.php; fi",
-			"if [ -f index.php.tmp ]; then mv index.php.tmp index.php; fi"
+			"@restore-backup-files"
 		],
-		"pre-install-cmd": "@pre-update-cmd",
-		"post-install-cmd": "@post-update-cmd",
+		"pre-install-cmd": "@backup-files",
+		"post-install-cmd": "@restore-backup-files",
 		"shellcheck": [
 			"shellcheck bin/*.sh"
 		],

--- a/composer.lock
+++ b/composer.lock
@@ -1860,15 +1860,15 @@
         },
         {
             "name": "wpackagist-plugin/ninja-forms",
-            "version": "3.10.2.2",
+            "version": "3.10.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.10.2.2"
+                "reference": "tags/3.10.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.10.2.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.10.3.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
This PR updates the `composer.json` scripts to always remove the auto-created `.build-scripts` file from Altis.

This also adds an updated `composer.json` which brings us the latest Ninja Forms