### PR TITLE
Add Object Cache Pro

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.4
+      - name: Setup auth.json
+        run: composer config --auth http-basic.objectcache.pro token ${{ secrets.OBJECTCACHE_PRO_TOKEN }}
       - name: Install Composer Dependencies
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
       - name: Setup Dashboard Changelog

--- a/.github/workflows/dry-run-deploy.yml
+++ b/.github/workflows/dry-run-deploy.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           php-version: 8.4
 
+      - name: Setup auth.json
+        run: composer config --auth http-basic.objectcache.pro token ${{ secrets.OBJECTCACHE_PRO_TOKEN }}
+
       - name: Install Composer Dependencies
         run: composer install --no-dev --optimize-autoloader --ignore-platform-reqs
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ xmlrpc.php
 index.php
 server-config.php
 readme.html
+auth.json
 
 # Backup files
 index.php.tmp

--- a/composer.json
+++ b/composer.json
@@ -145,6 +145,10 @@
 					"reference": "tags/v1.2.5"
 				}
 			}
+		},
+		{
+			"type": "composer",
+			"url": "https://objectcache.pro/repo/"			
 		}
 	],
 	"require": {
@@ -169,6 +173,7 @@
 		"jazzsequence/wp-show-tracker": "*",
 		"johnbillion/extended-cpts": "*",
 		"pantheon-systems/pantheon-content-publisher-for-wordpress": "1.2.5",
+		"rhubarbgroup/object-cache-pro": "*",
 		"wpackagist-plugin/akismet": "*",
 		"wpackagist-plugin/altis-accelerate": "*",
 		"wpackagist-plugin/amazon-s3-and-cloudfront": "*",
@@ -192,10 +197,10 @@
 		"wpackagist-theme/twentynineteen": "*",
 		"wpackagist-theme/twentyseventeen": "*",
 		"wpackagist-theme/twentytwenty": "*",
+		"wpackagist-theme/twentytwentyfive": "*",
 		"wpackagist-theme/twentytwentyone": "*",
 		"wpackagist-theme/twentytwentythree": "*",
-		"wpackagist-theme/twentytwentytwo": "*",
-		"wpackagist-theme/twentytwentyfive": "*"
+		"wpackagist-theme/twentytwentytwo": "*"
 	},
 	"replace":{
 		"johnpbloch/wordpress": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bbff4147b28c37ca2e412585c658106",
+    "content-hash": "74ebdc71a31ac8bd722f6d0b5fcb4a9d",
     "packages": [
         {
             "name": "10up/simple-local-avatars",
@@ -1676,6 +1676,50 @@
                 "reference": "tags/v1.2.5"
             },
             "type": "wordpress-plugin"
+        },
+        {
+            "name": "rhubarbgroup/object-cache-pro",
+            "version": "v1.24.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://objectcache.pro/plugin/object-cache-pro-1.24.2.zip?token=dd9cc75fa72816fe69f8b3ccc7b8f68ab6043278921d52c3a7990c67aae3",
+                "reference": "acfe64a924006cf62f6edc84e8e4770a091f3c91"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0",
+                "ext-redis": ">=4.0.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "suggest": {
+                "ext-redis": "Required to use PhpRedis as the object cache backend.",
+                "ext-relay": "Required to use Relay as the object cache backend."
+            },
+            "type": "wordpress-plugin",
+            "autoload": {
+                "psr-4": {
+                    "RedisCachePro\\": "src/"
+                },
+                "classmap": [
+                    "src/Support/Types.php",
+                    "src/Extensions/Debugbar/Panel.php",
+                    "src/Extensions/Debugbar/Insights.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                },
+                "exclude-from-classmap": [
+                    "tests/PHPStan/",
+                    "tests/bootstrap.php"
+                ]
+            },
+            "license": [
+                "proprietary"
+            ],
+            "description": "A business class Redis object cache backend for WordPress.",
+            "homepage": "https://objectcache.pro",
+            "time": "2025-06-20T15:46:38+00:00"
         },
         {
             "name": "stuttter/wp-user-signups",


### PR DESCRIPTION
This PR adds Object Cache Pro and updates the deploy workflows so they can install it via the `composer install` build step.