### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Test scripts](https://github.com/jazzsequence/jazzsequence.com/actions/workflows/test-scripts.yml/badge.svg)](https://github.com/jazzsequence/jazzsequence.com/actions/workflows/test-scripts.yml)
 [![Dry Run Deploy](https://github.com/jazzsequence/jazzsequence.com/actions/workflows/dry-run-deploy.yml/badge.svg)](https://github.com/jazzsequence/jazzsequence.com/actions/workflows/dry-run-deploy.yml)
 
-![jazzsequence.com 10 December, 2020](https://sfo2.digitaloceanspaces.com/cdn.jazzsequence/wp-content/uploads/2020/12/10120020/Screen-Shot-2020-12-10-at-11.59.56-AM.png)
+![jazzsequence.com 22 August, 2025](https://sfo2.digitaloceanspaces.com/cdn.jazzsequence/wp-content/uploads/2025/08/22112833/Screenshot-2025-08-22-at-11.27.19-AM.png)
 
 ## Technologies
 [jazzsequence.com](https://jazzsequence.com) is powered by the following technologies:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 <!-- TODO -->
 <!--
 * Move my plugins that are composerized to packagist so I don't need to use them as composer repositories
-* composerize plugins that arne't already so we can move them to packagist
-* move the deploy workflow off of DeployHQ and onto GitHub Actions
+* composerize plugins that aren't already so we can move them to packagist
 * change the dashboard "home" link to point back to the regular dashboard rather than the altis dashboard
 * use a pantheon sandbox to test the actual site before deploying to production
+* add a deploy to pantheon workflow to test code sync to pantheon while still syncing code to DO
 -->

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@
 
 <!-- TODO -->
 <!--
-* Move my plugins that are composerized to packagist so I don't need to use them as composer repositories
-* composerize plugins that aren't already so we can move them to packagist
 * change the dashboard "home" link to point back to the regular dashboard rather than the altis dashboard
 * use a pantheon sandbox to test the actual site before deploying to production
 * add a deploy to pantheon workflow to test code sync to pantheon while still syncing code to DO


### PR DESCRIPTION
Updates the readme to
* remove the TODO to move off of DeployHQ (done)
* fixes a typo
* adds a TODO to add a deploy to pantheon workflow that runs in parallel with deploying to DO
  * doing this means I can debug that workflow and make sure the site on Pantheon is working without having to switch everything
  * can also debug different types of workflows (e.g. the official [push to pantheon](https://github.com/pantheon-systems/push-to-pantheon) action vs just changing the rsync destination in the current GHA workflow)
