### PR TITLE
chore: remove local path repository to fix Dependabot composer updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,11 +57,6 @@
 		{
 			"type": "composer",
 			"url": "https://wpackagist.org"
-		},        
-		{
-			"type": "path",
-			"url": "./packages",
-			"symlinks": true
 		}
 	],
 	"require": {


### PR DESCRIPTION
The ./packages path repository caused Dependabot to fail resolving all composer dependencies since the directory does not exist in its cloned environment. jz-222 is already available via its VCS repository entry.