### PR TITLE
chore: gitignore index.php.bak backup artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ auth.json
 
 # Backup files
 index.php.tmp
+index.php.bak
 wp-config.php.bak
 
 # Don't ignore packages


### PR DESCRIPTION
`composer backup-files` creates `index.php.bak` alongside `wp-config.php.bak`, which was already gitignored. This adds the missing pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZgXRXwGig9VNAUmqYnb5t)_