### PR TITLE
chore: bump version to 1.11.6

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.11.5",
+  "version": "1.11.6",
   "versionDescription": "Updates and patches should always be x.x.Y patch updates. WordPress updates or major feature additions (like new plugins or themes) should be x.Y.x minor updates. Major site updates should be Y.x.x major updates."
 }


### PR DESCRIPTION
Patch bump for the upcoming release — dependency updates only, no new plugins/themes or WordPress major version change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZgXRXwGig9VNAUmqYnb5t)_