### PR TITLE
Release 1.11.6

### DIFF
--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Generate composer diff

--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Generate composer diff
         id: composer_diff
-        uses: IonBazan/composer-diff-action@v1
+        uses: IonBazan/composer-diff-action@v2
       - uses: marocchino/sticky-pull-request-comment@v3
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install SSH keys
         uses: webfactory/ssh-agent@v0.10.0
         with:

--- a/.github/workflows/dry-run-deploy.yml
+++ b/.github/workflows/dry-run-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install SSH Key
         uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install SVN
         run: sudo apt-get install -y subversion
       - name: Install dependencies

--- a/.github/workflows/phpunit-contact-form.yml
+++ b/.github/workflows/phpunit-contact-form.yml
@@ -29,7 +29,7 @@ jobs:
       WP_CORE_DIR: /tmp/wordpress
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit-mcp-abilities.yml
+++ b/.github/workflows/phpunit-mcp-abilities.yml
@@ -29,7 +29,7 @@ jobs:
       PLUGIN_DIR: wp-content/plugins/jazzsequence-mcp-abilities
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit-mcp-abilities.yml
+++ b/.github/workflows/phpunit-mcp-abilities.yml
@@ -40,7 +40,7 @@ jobs:
           tools: wp-cli
 
       - name: Cache plugin Composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ env.PLUGIN_DIR }}/vendor
           key: composer-plugin-${{ hashFiles(format('{0}/composer.lock', env.PLUGIN_DIR)) }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get version from version.json
         run: echo "VERSION=$(jq -r .version ./version.json)" >> $GITHUB_ENV
       - name: Set Git Config

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -5,7 +5,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install SVN
         run: sudo apt-get install -y subversion
       - name: Install dependencies
@@ -18,7 +18,7 @@ jobs:
       WORKSPACE_PATH: ${{ github.workspace }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install SVN
         run: sudo apt-get install -y subversion
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       VERSION: $(jq -r .version ${{ github.workspace }}/version.json) 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install Bats
         run: |
           git clone https://github.com/bats-core/bats-core.git

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ auth.json
 
 # Backup files
 index.php.tmp
+index.php.bak
 wp-config.php.bak
 
 # Don't ignore packages

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
 		"johnbillion/wp-crontrol": "^1.16",
 		"pantheon-systems/pantheon-wp-coding-standards": "^3.0",
 		"phpunit/phpunit": "^9.5",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -96,23 +96,23 @@
         },
         {
             "name": "altis/cms",
-            "version": "26.0.4",
+            "version": "26.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-cms.git",
-                "reference": "caa4218793b74b23f989508c83ce443a46636941"
+                "reference": "0f443b77c37a12afe6c7d8390c7c93cd01d98751"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/caa4218793b74b23f989508c83ce443a46636941",
-                "reference": "caa4218793b74b23f989508c83ce443a46636941",
+                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/0f443b77c37a12afe6c7d8390c7c93cd01d98751",
+                "reference": "0f443b77c37a12afe6c7d8390c7c93cd01d98751",
                 "shasum": ""
             },
             "require": {
                 "10up/simple-local-avatars": "~2.7.11",
                 "altis/cms-installer": "^0.4.4",
                 "humanmade/altis-reusable-blocks": "~0.2.4",
-                "humanmade/asset-loader": "^0.6.4",
+                "humanmade/asset-loader": "^0.6.4 || ^0.8.0",
                 "humanmade/clean-html": "^2.0.0",
                 "johnpbloch/wordpress": "6.9.4",
                 "php": ">=8.2",
@@ -159,9 +159,9 @@
             "description": "CMS Module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-cms/issues",
-                "source": "https://github.com/humanmade/altis-cms/tree/26.0.4"
+                "source": "https://github.com/humanmade/altis-cms/tree/26.0.8"
             },
-            "time": "2026-03-20T17:47:00+00:00"
+            "time": "2026-05-27T09:02:23+00:00"
         },
         {
             "name": "altis/cms-installer",
@@ -209,23 +209,23 @@
         },
         {
             "name": "altis/workflow",
-            "version": "15.0.0",
+            "version": "15.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-workflow.git",
-                "reference": "b17d6389063876b19efdb5e47ea3b4e6b2e64b28"
+                "reference": "e0c85987a51494224c6405dd87bfb83eda579486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/b17d6389063876b19efdb5e47ea3b4e6b2e64b28",
-                "reference": "b17d6389063876b19efdb5e47ea3b4e6b2e64b28",
+                "url": "https://api.github.com/repos/humanmade/altis-workflow/zipball/e0c85987a51494224c6405dd87bfb83eda579486",
+                "reference": "e0c85987a51494224c6405dd87bfb83eda579486",
                 "shasum": ""
             },
             "require": {
-                "humanmade/publication-checklist": "~0.3.0",
-                "humanmade/workflows": "~0.4.4",
-                "php": ">=7.1",
-                "yoast/duplicate-post": "~4.1.2"
+                "humanmade/publication-checklist": "~0.4.8",
+                "humanmade/workflows": "~0.4.10",
+                "php": ">=7.4",
+                "yoast/duplicate-post": "~4.6.0"
             },
             "type": "package",
             "extra": {
@@ -260,9 +260,9 @@
             "description": "Workflow module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-workflow/issues",
-                "source": "https://github.com/humanmade/altis-workflow/tree/15.0.0"
+                "source": "https://github.com/humanmade/altis-workflow/tree/15.0.1"
             },
-            "time": "2022-10-06T15:36:32+00:00"
+            "time": "2026-04-22T14:47:03+00:00"
         },
         {
             "name": "cmb2/cmb2",
@@ -973,16 +973,16 @@
         },
         {
             "name": "humanmade/publication-checklist",
-            "version": "0.3.3",
+            "version": "v0.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/publication-checklist.git",
-                "reference": "d4c19f7ad87db3442ad0b8d3c76076cc8f51b2df"
+                "reference": "8b2fbd02e1997c8956b8db7d068c302f834a6c8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/d4c19f7ad87db3442ad0b8d3c76076cc8f51b2df",
-                "reference": "d4c19f7ad87db3442ad0b8d3c76076cc8f51b2df",
+                "url": "https://api.github.com/repos/humanmade/publication-checklist/zipball/8b2fbd02e1997c8956b8db7d068c302f834a6c8d",
+                "reference": "8b2fbd02e1997c8956b8db7d068c302f834a6c8d",
                 "shasum": ""
             },
             "require": {
@@ -1002,9 +1002,9 @@
             "description": "Run checks and enforce conditions before posts are published.",
             "support": {
                 "issues": "https://github.com/humanmade/publication-checklist/issues",
-                "source": "https://github.com/humanmade/publication-checklist/tree/0.3.3"
+                "source": "https://github.com/humanmade/publication-checklist/tree/v0.4.8"
             },
-            "time": "2024-07-18T19:48:00+00:00"
+            "time": "2025-09-19T21:04:33+00:00"
         },
         {
             "name": "humanmade/two-factor",
@@ -1764,16 +1764,16 @@
         },
         {
             "name": "pfefferle/wordpress-activitypub",
-            "version": "8.0.2",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wordpress-activitypub.git",
-                "reference": "5c49b39dd520a8c8c672ecd73109cd1272bb7ad0"
+                "reference": "4aee8f92c26239a470f16a2117921aeac37f8762"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/5c49b39dd520a8c8c672ecd73109cd1272bb7ad0",
-                "reference": "5c49b39dd520a8c8c672ecd73109cd1272bb7ad0",
+                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/4aee8f92c26239a470f16a2117921aeac37f8762",
+                "reference": "4aee8f92c26239a470f16a2117921aeac37f8762",
                 "shasum": ""
             },
             "require": {
@@ -1781,13 +1781,13 @@
                 "php": ">=7.4"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "6.0.0",
+                "automattic/jetpack-changelogger": "6.0.16",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
                 "dms/phpunit-arraysubset-asserts": "^0.5.0",
                 "phpcompatibility/php-compatibility": "*",
                 "phpcompatibility/phpcompatibility-wp": "*",
                 "phpcsstandards/phpcsextra": "^1.1.0",
-                "phpunit/phpunit": "^9",
+                "phpunit/phpunit": "^9.6.33",
                 "sirbrillig/phpcs-variable-analysis": "^2.11",
                 "squizlabs/php_codesniffer": "3.*",
                 "wp-coding-standards/wpcs": "dev-develop",
@@ -1814,9 +1814,9 @@
             "description": "The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.",
             "support": {
                 "issues": "https://github.com/Automattic/wordpress-activitypub/issues",
-                "source": "https://github.com/Automattic/wordpress-activitypub/tree/8.0.2"
+                "source": "https://github.com/Automattic/wordpress-activitypub/tree/9.0.1"
             },
-            "time": "2026-03-17T11:21:25+00:00"
+            "time": "2026-06-15T13:12:54+00:00"
         },
         {
             "name": "stuttter/wp-user-signups",
@@ -1857,23 +1857,26 @@
         },
         {
             "name": "wordpress/mcp-adapter",
-            "version": "v0.4.1",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/mcp-adapter.git",
-                "reference": "1a0f9ab868e34b4375be42e873f60765e6632505"
+                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/1a0f9ab868e34b4375be42e873f60765e6632505",
-                "reference": "1a0f9ab868e34b4375be42e873f60765e6632505",
+                "url": "https://api.github.com/repos/WordPress/mcp-adapter/zipball/7bfc49f46b3ea7544dded49d5a606089f825a80b",
+                "reference": "7bfc49f46b3ea7544dded49d5a606089f825a80b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0"
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "wordpress/php-mcp-schema": "^0.1.0"
             },
             "require-dev": {
                 "automattic/vipwpcs": "^3.0",
+                "php-stubs/wordpress-stubs": "^6.9",
                 "php-stubs/wp-cli-stubs": "^2.12",
                 "phpcompatibility/php-compatibility": "10.x-dev as 9.99.99",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -1888,7 +1891,7 @@
                 "wpackagist-plugin/plugin-check": "^1.6",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "type": "library",
+            "type": "wordpress-plugin",
             "extra": {
                 "installer-paths": {
                     "vendor/{$vendor}/{$name}/": [
@@ -1927,19 +1930,66 @@
                 "issues": "https://github.com/wordpress/mcp-adapter/issues",
                 "source": "https://github.com/wordpress/mcp-adapter"
             },
-            "time": "2025-12-09T06:56:51+00:00"
+            "time": "2026-04-14T12:12:58+00:00"
         },
         {
-            "name": "wp-plugin/akismet",
-            "version": "5.6",
+            "name": "wordpress/php-mcp-schema",
+            "version": "v0.1.2",
             "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/akismet/",
-                "reference": "tags/5.6"
+                "type": "git",
+                "url": "https://github.com/WordPress/php-mcp-schema",
+                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/akismet.5.6.zip"
+                "url": "https://api.github.com/repos/WordPress/php-mcp-schema/zipball/95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
+                "reference": "95df8a50a3bd54f6b7c4869c6e2185db380d4d63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP\\McpSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "WordPress",
+                    "homepage": "https://wordpress.org"
+                }
+            ],
+            "description": "PHP DTOs for the Model Context Protocol (MCP) specification",
+            "homepage": "https://github.com/WordPress/php-mcp-schema",
+            "keywords": [
+                "dto",
+                "mcp",
+                "model-context-protocol",
+                "php",
+                "schema"
+            ],
+            "time": "2026-06-05T08:26:32+00:00"
+        },
+        {
+            "name": "wp-plugin/akismet",
+            "version": "5.7",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/akismet/",
+                "reference": "tags/5.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/akismet.5.7.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -1958,19 +2008,19 @@
                 "issues": "https://wordpress.org/support/plugin/akismet",
                 "source": "https://plugins.svn.wordpress.org/akismet"
             },
-            "time": "2026-03-26T20:55:32+00:00"
+            "time": "2026-05-01T00:26:06+00:00"
         },
         {
             "name": "wp-plugin/altis-accelerate",
-            "version": "4.1.2",
+            "version": "4.2.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/altis-accelerate/",
-                "reference": "tags/4.1.2"
+                "reference": "tags/4.2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.1.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.2.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -1988,19 +2038,19 @@
                 "issues": "https://wordpress.org/support/plugin/altis-accelerate",
                 "source": "https://plugins.svn.wordpress.org/altis-accelerate"
             },
-            "time": "2026-03-31T18:35:49+00:00"
+            "time": "2026-06-11T18:00:46+00:00"
         },
         {
             "name": "wp-plugin/amazon-s3-and-cloudfront",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/amazon-s3-and-cloudfront/",
-                "reference": "tags/3.3.0"
+                "reference": "tags/3.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.3.3.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/amazon-s3-and-cloudfront.3.3.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2019,19 +2069,19 @@
                 "issues": "https://wordpress.org/support/plugin/amazon-s3-and-cloudfront",
                 "source": "https://plugins.svn.wordpress.org/amazon-s3-and-cloudfront"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-04-15T13:10:40+00:00"
         },
         {
             "name": "wp-plugin/autoblue",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/autoblue/",
-                "reference": "tags/1.0.0"
+                "reference": "tags/2.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/autoblue.1.0.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/autoblue.2.0.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2050,7 +2100,7 @@
                 "issues": "https://wordpress.org/support/plugin/autoblue",
                 "source": "https://plugins.svn.wordpress.org/autoblue"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-31T22:21:16+00:00"
         },
         {
             "name": "wp-plugin/bv-pantheon-migration",
@@ -2116,15 +2166,15 @@
         },
         {
             "name": "wp-plugin/gutenberg",
-            "version": "22.8.2",
+            "version": "23.3.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/22.8.2"
+                "reference": "tags/23.3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.22.8.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.23.3.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2133,7 +2183,7 @@
             "notification-url": "https://wp-packages.org/downloads",
             "authors": [
                 {
-                    "name": "Matias Ventura"
+                    "name": "WordPress.org"
                 }
             ],
             "description": "The Gutenberg plugin adds editing, customization, and site building to WordPress. Use it to test beta features before their official release.",
@@ -2143,7 +2193,7 @@
                 "issues": "https://wordpress.org/support/plugin/gutenberg",
                 "source": "https://plugins.svn.wordpress.org/gutenberg"
             },
-            "time": "2026-03-30T09:50:51+00:00"
+            "time": "2026-06-04T14:35:51+00:00"
         },
         {
             "name": "wp-plugin/hello-ziggy",
@@ -2177,15 +2227,15 @@
         },
         {
             "name": "wp-plugin/litespeed-cache",
-            "version": "7.8.0.1",
+            "version": "7.8.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/litespeed-cache/",
-                "reference": "tags/7.8.0.1"
+                "reference": "tags/7.8.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/litespeed-cache.7.8.0.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/litespeed-cache.7.8.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2204,19 +2254,19 @@
                 "issues": "https://wordpress.org/support/plugin/litespeed-cache",
                 "source": "https://plugins.svn.wordpress.org/litespeed-cache"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-04-01T16:55:50+00:00"
         },
         {
             "name": "wp-plugin/ninja-forms",
-            "version": "3.14.2",
+            "version": "3.14.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.14.2"
+                "reference": "tags/3.14.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2235,19 +2285,19 @@
                 "issues": "https://wordpress.org/support/plugin/ninja-forms",
                 "source": "https://plugins.svn.wordpress.org/ninja-forms"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-06-08T14:06:53+00:00"
         },
         {
             "name": "wp-plugin/organize-series",
-            "version": "3.1.0",
+            "version": "3.1.2",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/organize-series/",
-                "reference": "tags/3.1.0"
+                "reference": "tags/3.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/organize-series.3.1.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/organize-series.3.1.2.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2266,7 +2316,7 @@
                 "issues": "https://wordpress.org/support/plugin/organize-series",
                 "source": "https://plugins.svn.wordpress.org/organize-series"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-21T18:46:41+00:00"
         },
         {
             "name": "wp-plugin/pantheon-content-publisher",
@@ -2301,15 +2351,15 @@
         },
         {
             "name": "wp-plugin/patchstack",
-            "version": "2.3.5",
+            "version": "2.3.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/patchstack/",
-                "reference": "tags/2.3.5"
+                "reference": "tags/2.3.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/patchstack.2.3.5.zip"
+                "url": "https://downloads.wordpress.org/plugin/patchstack.2.3.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2328,7 +2378,7 @@
                 "issues": "https://wordpress.org/support/plugin/patchstack",
                 "source": "https://plugins.svn.wordpress.org/patchstack"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-04-22T07:15:45+00:00"
         },
         {
             "name": "wp-plugin/plugins-garbage-collector",
@@ -2394,15 +2444,15 @@
         },
         {
             "name": "wp-plugin/query-monitor",
-            "version": "3.20.4",
+            "version": "4.0.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/3.20.4"
+                "reference": "tags/4.0.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.3.20.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.4.0.6.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2421,7 +2471,7 @@
                 "issues": "https://wordpress.org/support/plugin/query-monitor",
                 "source": "https://plugins.svn.wordpress.org/query-monitor"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-04-11T11:56:17+00:00"
         },
         {
             "name": "wp-plugin/regenerate-thumbnails",
@@ -2576,15 +2626,15 @@
         },
         {
             "name": "wp-plugin/wp-mail-smtp",
-            "version": "4.7.1",
+            "version": "4.8.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
-                "reference": "tags/4.7.1"
+                "reference": "tags/4.8.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.7.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.8.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2603,7 +2653,7 @@
                 "issues": "https://wordpress.org/support/plugin/wp-mail-smtp",
                 "source": "https://plugins.svn.wordpress.org/wp-mail-smtp"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-04-16T15:16:32+00:00"
         },
         {
             "name": "wp-theme/museum-core",
@@ -2659,15 +2709,15 @@
         },
         {
             "name": "wp-theme/twentynineteen",
-            "version": "3.2",
+            "version": "3.3",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentynineteen/",
-                "reference": "3.2"
+                "reference": "3.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentynineteen.3.2.zip"
+                "url": "https://downloads.wordpress.org/theme/twentynineteen.3.3.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2681,19 +2731,19 @@
                 "issues": "https://wordpress.org/support/theme/twentynineteen",
                 "source": "https://themes.svn.wordpress.org/twentynineteen"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-20T21:51:08+00:00"
         },
         {
             "name": "wp-theme/twentyseventeen",
-            "version": "4.0",
+            "version": "4.1",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentyseventeen/",
-                "reference": "4.0"
+                "reference": "4.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentyseventeen.4.0.zip"
+                "url": "https://downloads.wordpress.org/theme/twentyseventeen.4.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2707,19 +2757,19 @@
                 "issues": "https://wordpress.org/support/theme/twentyseventeen",
                 "source": "https://themes.svn.wordpress.org/twentyseventeen"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-20T21:46:55+00:00"
         },
         {
             "name": "wp-theme/twentytwenty",
-            "version": "3.0",
+            "version": "3.1",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentytwenty/",
-                "reference": "3.0"
+                "reference": "3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentytwenty.3.0.zip"
+                "url": "https://downloads.wordpress.org/theme/twentytwenty.3.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2733,19 +2783,19 @@
                 "issues": "https://wordpress.org/support/theme/twentytwenty",
                 "source": "https://themes.svn.wordpress.org/twentytwenty"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-20T21:51:08+00:00"
         },
         {
             "name": "wp-theme/twentytwentyfive",
-            "version": "1.4",
+            "version": "1.5",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentytwentyfive/",
-                "reference": "1.4"
+                "reference": "1.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentytwentyfive.1.4.zip"
+                "url": "https://downloads.wordpress.org/theme/twentytwentyfive.1.5.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2759,19 +2809,19 @@
                 "issues": "https://wordpress.org/support/theme/twentytwentyfive",
                 "source": "https://themes.svn.wordpress.org/twentytwentyfive"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-20T21:56:34+00:00"
         },
         {
             "name": "wp-theme/twentytwentyone",
-            "version": "2.7",
+            "version": "2.8",
             "source": {
                 "type": "svn",
                 "url": "https://themes.svn.wordpress.org/twentytwentyone/",
-                "reference": "2.7"
+                "reference": "2.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/theme/twentytwentyone.2.7.zip"
+                "url": "https://downloads.wordpress.org/theme/twentytwentyone.2.8.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2785,7 +2835,7 @@
                 "issues": "https://wordpress.org/support/theme/twentytwentyone",
                 "source": "https://themes.svn.wordpress.org/twentytwentyone"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-05-20T21:56:34+00:00"
         },
         {
             "name": "wp-theme/twentytwentythree",

--- a/composer.lock
+++ b/composer.lock
@@ -53,16 +53,16 @@
         },
         {
             "name": "altis/browser-security",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-browser-security.git",
-                "reference": "d0326418a717e85f5d3fffcde99104fd39b40e24"
+                "reference": "82f1080b215528964074376a8519d63e41b691e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-browser-security/zipball/d0326418a717e85f5d3fffcde99104fd39b40e24",
-                "reference": "d0326418a717e85f5d3fffcde99104fd39b40e24",
+                "url": "https://api.github.com/repos/humanmade/altis-browser-security/zipball/82f1080b215528964074376a8519d63e41b691e4",
+                "reference": "82f1080b215528964074376a8519d63e41b691e4",
                 "shasum": ""
             },
             "require": {
@@ -90,22 +90,22 @@
             "description": "Browser security utilities for WordPress/Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-browser-security/issues",
-                "source": "https://github.com/humanmade/altis-browser-security/tree/2.2.0"
+                "source": "https://github.com/humanmade/altis-browser-security/tree/2.2.1"
             },
-            "time": "2026-02-24T16:35:17+00:00"
+            "time": "2026-05-22T16:25:44+00:00"
         },
         {
             "name": "altis/cms",
-            "version": "27.0.1",
+            "version": "27.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-cms.git",
-                "reference": "05af7fa5bbc82adb7f4c06b528977cde6750ca74"
+                "reference": "1df9e270e03652d592251431cc28e4af412285b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/05af7fa5bbc82adb7f4c06b528977cde6750ca74",
-                "reference": "05af7fa5bbc82adb7f4c06b528977cde6750ca74",
+                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/1df9e270e03652d592251431cc28e4af412285b5",
+                "reference": "1df9e270e03652d592251431cc28e4af412285b5",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "altis/cms-installer": "^0.4.4",
                 "humanmade/asset-loader": "^0.8.0",
                 "humanmade/clean-html": "^2.0.0",
-                "johnpbloch/wordpress": "7.0.0",
+                "johnpbloch/wordpress": "7.0.2",
                 "php": ">=8.2",
                 "stuttter/wp-user-signups": "^5.0.2"
             },
@@ -157,9 +157,9 @@
             "description": "CMS Module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-cms/issues",
-                "source": "https://github.com/humanmade/altis-cms/tree/27.0.1"
+                "source": "https://github.com/humanmade/altis-cms/tree/27.0.3"
             },
-            "time": "2026-06-25T17:26:25+00:00"
+            "time": "2026-07-17T19:34:30+00:00"
         },
         {
             "name": "altis/cms-installer",
@@ -1724,16 +1724,16 @@
         },
         {
             "name": "pfefferle/wordpress-activitypub",
-            "version": "9.0.2",
+            "version": "9.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wordpress-activitypub.git",
-                "reference": "280a7b795b4a6154262fcf8900f90f96f3ef6316"
+                "reference": "b29971ecfe0daf5bcfc71d8440d51a0f2708330a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/280a7b795b4a6154262fcf8900f90f96f3ef6316",
-                "reference": "280a7b795b4a6154262fcf8900f90f96f3ef6316",
+                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/b29971ecfe0daf5bcfc71d8440d51a0f2708330a",
+                "reference": "b29971ecfe0daf5bcfc71d8440d51a0f2708330a",
                 "shasum": ""
             },
             "require": {
@@ -1741,14 +1741,14 @@
                 "php": ">=7.4"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "6.0.16",
+                "automattic/jetpack-changelogger": "6.0.17",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
                 "dms/phpunit-arraysubset-asserts": "^0.5.0",
                 "phpcompatibility/php-compatibility": "*",
                 "phpcompatibility/phpcompatibility-wp": "*",
                 "phpcsstandards/phpcsextra": "^1.1.0",
                 "phpunit/phpunit": "^9.6.33",
-                "sirbrillig/phpcs-variable-analysis": "^2.11",
+                "sirbrillig/phpcs-variable-analysis": "^3.0",
                 "squizlabs/php_codesniffer": "3.*",
                 "wp-coding-standards/wpcs": "dev-develop",
                 "yoast/phpunit-polyfills": "^4.0"
@@ -1774,9 +1774,9 @@
             "description": "The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.",
             "support": {
                 "issues": "https://github.com/Automattic/wordpress-activitypub/issues",
-                "source": "https://github.com/Automattic/wordpress-activitypub/tree/9.0.2"
+                "source": "https://github.com/Automattic/wordpress-activitypub/tree/9.2.1"
             },
-            "time": "2026-06-29T08:21:15+00:00"
+            "time": "2026-08-03T11:14:27+00:00"
         },
         {
             "name": "stuttter/wp-user-signups",
@@ -1972,15 +1972,15 @@
         },
         {
             "name": "wp-plugin/altis-accelerate",
-            "version": "4.3.1",
+            "version": "4.3.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/altis-accelerate/",
-                "reference": "tags/4.3.1"
+                "reference": "tags/4.3.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.3.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.3.3.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -1998,7 +1998,7 @@
                 "issues": "https://wordpress.org/support/plugin/altis-accelerate",
                 "source": "https://plugins.svn.wordpress.org/altis-accelerate"
             },
-            "time": "2026-06-26T14:45:41+00:00"
+            "time": "2026-07-28T23:01:11+00:00"
         },
         {
             "name": "wp-plugin/amazon-s3-and-cloudfront",
@@ -2126,15 +2126,15 @@
         },
         {
             "name": "wp-plugin/gutenberg",
-            "version": "23.4.0",
+            "version": "23.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/23.4.0"
+                "reference": "tags/23.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.23.4.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.23.7.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2153,7 +2153,7 @@
                 "issues": "https://wordpress.org/support/plugin/gutenberg",
                 "source": "https://plugins.svn.wordpress.org/gutenberg"
             },
-            "time": "2026-06-17T08:51:03+00:00"
+            "time": "2026-08-05T15:16:43+00:00"
         },
         {
             "name": "wp-plugin/hello-ziggy",
@@ -2187,15 +2187,15 @@
         },
         {
             "name": "wp-plugin/litespeed-cache",
-            "version": "7.8.1",
+            "version": "7.9",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/litespeed-cache/",
-                "reference": "tags/7.8.1"
+                "reference": "tags/7.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/litespeed-cache.7.8.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/litespeed-cache.7.9.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2214,19 +2214,19 @@
                 "issues": "https://wordpress.org/support/plugin/litespeed-cache",
                 "source": "https://plugins.svn.wordpress.org/litespeed-cache"
             },
-            "time": "2026-04-01T16:55:50+00:00"
+            "time": "2026-08-05T21:16:27+00:00"
         },
         {
             "name": "wp-plugin/ninja-forms",
-            "version": "3.14.7",
+            "version": "3.14.11",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.14.7"
+                "reference": "tags/3.14.11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.7.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.11.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2245,7 +2245,7 @@
                 "issues": "https://wordpress.org/support/plugin/ninja-forms",
                 "source": "https://plugins.svn.wordpress.org/ninja-forms"
             },
-            "time": "2026-06-22T14:45:51+00:00"
+            "time": "2026-07-27T11:50:43+00:00"
         },
         {
             "name": "wp-plugin/organize-series",
@@ -2311,15 +2311,15 @@
         },
         {
             "name": "wp-plugin/patchstack",
-            "version": "2.3.6",
+            "version": "2.3.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/patchstack/",
-                "reference": "tags/2.3.6"
+                "reference": "tags/2.3.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/patchstack.2.3.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/patchstack.2.3.7.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2338,7 +2338,7 @@
                 "issues": "https://wordpress.org/support/plugin/patchstack",
                 "source": "https://plugins.svn.wordpress.org/patchstack"
             },
-            "time": "2026-04-22T07:15:45+00:00"
+            "time": "2026-07-28T07:56:08+00:00"
         },
         {
             "name": "wp-plugin/plugins-garbage-collector",
@@ -2555,15 +2555,15 @@
         },
         {
             "name": "wp-plugin/wp-crontrol",
-            "version": "1.21.0",
+            "version": "1.21.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-crontrol/",
-                "reference": "tags/1.21.0"
+                "reference": "tags/1.21.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.21.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.21.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2575,14 +2575,14 @@
                     "name": "John Blackbourn"
                 }
             ],
-            "description": "WP Crontrol enables you to take control of the cron events on your WordPress website.",
+            "description": "Take control of the cron events on your WordPress website or WooCommerce store with WP Crontrol.",
             "homepage": "https://wp-crontrol.com",
             "support": {
                 "changelog": "https://wordpress.org/plugins/wp-crontrol/#developers",
                 "issues": "https://wordpress.org/support/plugin/wp-crontrol",
                 "source": "https://plugins.svn.wordpress.org/wp-crontrol"
             },
-            "time": "2026-03-23T19:23:21+00:00"
+            "time": "2026-07-31T15:50:47+00:00"
         },
         {
             "name": "wp-plugin/wp-mail-smtp",

--- a/composer.lock
+++ b/composer.lock
@@ -3237,16 +3237,16 @@
         },
         {
             "name": "johnbillion/query-monitor",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/query-monitor.git",
-                "reference": "eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501"
+                "reference": "50c3cad9f710b3edcb00f266687d351d9f2c3ac6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/query-monitor/zipball/eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501",
-                "reference": "eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501",
+                "url": "https://api.github.com/repos/johnbillion/query-monitor/zipball/50c3cad9f710b3edcb00f266687d351d9f2c3ac6",
+                "reference": "50c3cad9f710b3edcb00f266687d351d9f2c3ac6",
                 "shasum": ""
             },
             "require": {
@@ -3256,9 +3256,9 @@
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
                 "guzzlehttp/guzzle": "^7.0",
-                "johnbillion/plugin-infrastructure": "2.9.0",
-                "johnbillion/wp-compat": "1.4.0",
-                "php-stubs/wordpress-stubs": "6.9.0",
+                "johnbillion/plugin-infrastructure": "2.9.4",
+                "johnbillion/wp-compat": "1.5.0",
+                "php-stubs/wordpress-stubs": "7.0.0 as 6.9.4",
                 "php-stubs/wp-cli-stubs": "2.12.0",
                 "phpcompatibility/phpcompatibility-wp": "2.1.5",
                 "phpstan/phpstan": "2.1.46",
@@ -3289,7 +3289,7 @@
                     "homepage": "https://johnblackbourn.com/"
                 }
             ],
-            "description": "The Developer Tools panel for WordPress.",
+            "description": "Query Monitor is the developer tools panel for WordPress and WooCommerce.",
             "homepage": "https://querymonitor.com/",
             "support": {
                 "forum": "https://wordpress.org/support/plugin/query-monitor",
@@ -3303,7 +3303,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-11T11:49:51+00:00"
+            "time": "2026-06-20T20:10:50+00:00"
         },
         {
             "name": "johnbillion/wp-crontrol",

--- a/composer.lock
+++ b/composer.lock
@@ -2920,32 +2920,32 @@
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/9c47cd036754e0e5f354a9914568f052043c3f30",
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.11",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
-                "squizlabs/php_codesniffer": "^3.9.2",
-                "wp-coding-standards/wpcs": "^3.1.0"
+                "php": ">=7.4",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "sirbrillig/phpcs-variable-analysis": "^2.13.0",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2970,7 +2970,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2024-05-10T20:31:09+00:00"
+            "time": "2026-07-27T14:33:48+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -3267,16 +3267,16 @@
         },
         {
             "name": "johnbillion/wp-crontrol",
-            "version": "1.21.0",
+            "version": "1.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/wp-crontrol.git",
-                "reference": "935fd1c066ef66dd86b6d08fba5d7ca3121e5d0d"
+                "reference": "3c75f84f9cf182f4167e93da7e24f883ba302461"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/wp-crontrol/zipball/935fd1c066ef66dd86b6d08fba5d7ca3121e5d0d",
-                "reference": "935fd1c066ef66dd86b6d08fba5d7ca3121e5d0d",
+                "url": "https://api.github.com/repos/johnbillion/wp-crontrol/zipball/3c75f84f9cf182f4167e93da7e24f883ba302461",
+                "reference": "3c75f84f9cf182f4167e93da7e24f883ba302461",
                 "shasum": ""
             },
             "require": {
@@ -3284,13 +3284,13 @@
                 "php": ">=7.4"
             },
             "require-dev": {
-                "johnbillion/plugin-infrastructure": "2.5.1",
+                "johnbillion/plugin-infrastructure": "2.9.5",
                 "johnbillion/wp-compat": "1.4.0",
-                "php-stubs/wordpress-stubs": "6.9.0",
+                "php-stubs/wordpress-stubs": "7.0.0 as 6.9.4",
                 "phpcompatibility/phpcompatibility-wp": "2.1.8",
                 "phpstan/phpstan": "2.1.33",
                 "szepeviktor/phpstan-wordpress": "2.0.3",
-                "wp-coding-standards/wpcs": "3.3.0"
+                "wp-coding-standards/wpcs": "3.4.1"
             },
             "type": "wordpress-plugin",
             "extra": {
@@ -3315,7 +3315,7 @@
                     "homepage": "http://scompt.com/"
                 }
             ],
-            "description": "Take control of the cron events on your WordPress website",
+            "description": "Take control of the cron events on your WordPress website or WooCommerce store",
             "homepage": "https://wp-crontrol.com",
             "support": {
                 "forum": "https://wordpress.org/support/plugin/wp-crontrol",
@@ -3329,7 +3329,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-28T21:13:49+00:00"
+            "time": "2026-07-31T15:46:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3451,23 +3451,23 @@
         },
         {
             "name": "pantheon-systems/pantheon-wp-coding-standards",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
-                "reference": "40a97fc4da4611f5f63f460211ff1e7d59b71f72"
+                "reference": "5622da81ffd27b9125bd1b9c1d3a4f3de193248f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/40a97fc4da4611f5f63f460211ff1e7d59b71f72",
-                "reference": "40a97fc4da4611f5f63f460211ff1e7d59b71f72",
+                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/5622da81ffd27b9125bd1b9c1d3a4f3de193248f",
+                "reference": "5622da81ffd27b9125bd1b9c1d3a4f3de193248f",
                 "shasum": ""
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
                 "fig-r/psr2r-sniffer": "^2.2",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "wp-coding-standards/wpcs": "^3.0"
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "squizlabs/php_codesniffer": "^3.13",
@@ -3493,9 +3493,9 @@
             "description": "PHPCS Rulesets for WordPress projects on Pantheon.",
             "support": {
                 "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
-                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/3.0.1"
+                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/3.0.2"
             },
-            "time": "2025-07-21T20:47:08+00:00"
+            "time": "2026-07-28T16:59:09+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4068,16 +4068,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -4109,9 +4109,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -5679,16 +5679,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -5754,7 +5754,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -2974,16 +2974,16 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -3066,7 +3066,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -3893,21 +3893,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -3971,20 +3971,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -4064,7 +4064,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -5808,16 +5808,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.3.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
-                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -5826,9 +5826,9 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.1.0",
-                "squizlabs/php_codesniffer": "^3.13.4"
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -5870,7 +5870,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2025-11-25T12:08:04+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c17ef21353c60d6cd4d2ad1494d18080",
+    "content-hash": "5ab815b4f776d321b954c33e0ae07aa0",
     "packages": [
         {
             "name": "10up/simple-local-avatars",
@@ -1218,30 +1218,6 @@
                 "source": "https://github.com/jazzsequence/Address-Book/tree/0.3.5"
             },
             "time": "2025-07-01T14:52:16+00:00"
-        },
-        {
-            "name": "jazzsequence/artists",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jazzsequence/artists.git",
-                "reference": "ff352d7b8c7d302966d00b9fe0cc3c043bfaaa27"
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Reynolds",
-                    "homepage": "https://jazzsequence.com"
-                }
-            ],
-            "description": "A WordPress plugin for music artists, to be used in conjunction with Releases",
-            "support": {
-                "issues": "https://github.com/jazzsequence/artists/issues",
-                "source": "https://github.com/jazzsequence/artists"
-            }
         },
         {
             "name": "jazzsequence/dashboard-changelog",
@@ -3211,16 +3187,16 @@
         },
         {
             "name": "johnbillion/query-monitor",
-            "version": "3.20.4",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/query-monitor.git",
-                "reference": "19a230464200294ae0448e5d3487be5537de0622"
+                "reference": "eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/query-monitor/zipball/19a230464200294ae0448e5d3487be5537de0622",
-                "reference": "19a230464200294ae0448e5d3487be5537de0622",
+                "url": "https://api.github.com/repos/johnbillion/query-monitor/zipball/eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501",
+                "reference": "eaa67a8f5e6ca24cceb4d4daf9cc27c32cc8f501",
                 "shasum": ""
             },
             "require": {
@@ -3228,24 +3204,18 @@
                 "php": ">=7.4.0"
             },
             "require-dev": {
-                "behat/gherkin": "< 4.13.0",
-                "codeception/module-asserts": "^1.0",
-                "codeception/module-db": "^1.0",
-                "codeception/module-webdriver": "^1.0",
-                "codeception/util-universalframework": "^1.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
                 "guzzlehttp/guzzle": "^7.0",
-                "johnbillion/plugin-infrastructure": "1.2.2",
-                "johnbillion/wp-compat": "0.3.1",
-                "lucatume/wp-browser": "3.2.3",
+                "johnbillion/plugin-infrastructure": "2.9.0",
+                "johnbillion/wp-compat": "1.4.0",
+                "php-stubs/wordpress-stubs": "6.9.0",
+                "php-stubs/wp-cli-stubs": "2.12.0",
                 "phpcompatibility/phpcompatibility-wp": "2.1.5",
-                "phpstan/phpstan": "1.12.11",
-                "phpstan/phpstan-deprecation-rules": "1.2.1",
-                "phpstan/phpstan-phpunit": "1.4.1",
-                "roots/wordpress-core-installer": "1.100.0",
-                "roots/wordpress-full": "*",
+                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
                 "squizlabs/php_codesniffer": "3.11.1",
-                "szepeviktor/phpstan-wordpress": "1.3.5",
+                "szepeviktor/phpstan-wordpress": "2.0.3",
                 "wp-coding-standards/wpcs": "2.3.0"
             },
             "type": "wordpress-plugin",
@@ -3283,7 +3253,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-19T17:07:45+00:00"
+            "time": "2026-04-11T11:49:51+00:00"
         },
         {
             "name": "johnbillion/wp-crontrol",
@@ -4673,6 +4643,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-26T13:08:54+00:00"
         },
         {
@@ -4728,6 +4699,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-28T05:30:19+00:00"
         },
         {
@@ -5892,26 +5864,26 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.5",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0"
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
-                "reference": "41aaac462fbd80feb8dd129e489f4bbc53fe26b0",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "yoast/yoastcs": "^3.2.0"
+                "yoast/yoastcs": "^3.1.0"
             },
             "type": "library",
             "extra": {
@@ -5951,7 +5923,7 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-08-10T04:54:36+00:00"
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [
@@ -5974,5 +5946,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -96,25 +96,24 @@
         },
         {
             "name": "altis/cms",
-            "version": "26.0.8",
+            "version": "27.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/altis-cms.git",
-                "reference": "0f443b77c37a12afe6c7d8390c7c93cd01d98751"
+                "reference": "05af7fa5bbc82adb7f4c06b528977cde6750ca74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/0f443b77c37a12afe6c7d8390c7c93cd01d98751",
-                "reference": "0f443b77c37a12afe6c7d8390c7c93cd01d98751",
+                "url": "https://api.github.com/repos/humanmade/altis-cms/zipball/05af7fa5bbc82adb7f4c06b528977cde6750ca74",
+                "reference": "05af7fa5bbc82adb7f4c06b528977cde6750ca74",
                 "shasum": ""
             },
             "require": {
                 "10up/simple-local-avatars": "~2.7.11",
                 "altis/cms-installer": "^0.4.4",
-                "humanmade/altis-reusable-blocks": "~0.2.4",
-                "humanmade/asset-loader": "^0.6.4 || ^0.8.0",
+                "humanmade/asset-loader": "^0.8.0",
                 "humanmade/clean-html": "^2.0.0",
-                "johnpbloch/wordpress": "6.9.4",
+                "johnpbloch/wordpress": "7.0.0",
                 "php": ">=8.2",
                 "stuttter/wp-user-signups": "^5.0.2"
             },
@@ -124,7 +123,6 @@
                     "install-overrides": [
                         "10up/simple-local-avatars",
                         "stuttter/wp-user-signups",
-                        "humanmade/altis-reusable-blocks",
                         "humanmade/asset-loader"
                     ]
                 }
@@ -159,9 +157,9 @@
             "description": "CMS Module for Altis",
             "support": {
                 "issues": "https://github.com/humanmade/altis-cms/issues",
-                "source": "https://github.com/humanmade/altis-cms/tree/26.0.8"
+                "source": "https://github.com/humanmade/altis-cms/tree/27.0.1"
             },
-            "time": "2026-05-27T09:02:23+00:00"
+            "time": "2026-06-25T17:26:25+00:00"
         },
         {
             "name": "altis/cms-installer",
@@ -583,46 +581,6 @@
             "time": "2018-06-28T20:32:51+00:00"
         },
         {
-            "name": "humanmade/altis-reusable-blocks",
-            "version": "v0.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/humanmade/altis-reusable-blocks.git",
-                "reference": "722da82ad03cc6ccc3903ddba6dbc5a19c8cbdf7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/altis-reusable-blocks/zipball/722da82ad03cc6ccc3903ddba6dbc5a19c8cbdf7",
-                "reference": "722da82ad03cc6ccc3903ddba6dbc5a19c8cbdf7",
-                "shasum": ""
-            },
-            "require": {
-                "composer/installers": "^1.7",
-                "humanmade/asset-loader": "^0.5.0 || ^0.6.1",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "automattic/vipwpcs": "^2.0",
-                "brain/monkey": "^2.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "mockery/mockery": "^1.2",
-                "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "phpunit/phpunit": "^7.5",
-                "squizlabs/php_codesniffer": "^3.4"
-            },
-            "type": "wordpress-plugin",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Adds functionality to reusable blocks to enhance their usage.",
-            "support": {
-                "issues": "https://github.com/humanmade/altis-reusable-blocks/issues",
-                "source": "https://github.com/humanmade/altis-reusable-blocks/tree/v0.2.4"
-            },
-            "time": "2022-12-13T13:36:34+00:00"
-        },
-        {
             "name": "humanmade/amf-unsplash",
             "version": "0.3.0",
             "source": {
@@ -660,25 +618,27 @@
         },
         {
             "name": "humanmade/asset-loader",
-            "version": "v0.6.4",
+            "version": "v0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/asset-loader.git",
-                "reference": "1cc2bdcae19b2c6a4900df3cf827ab573ed0beac"
+                "reference": "f91409a9a8fae5981a65e3017dbd58175b5bcac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/asset-loader/zipball/1cc2bdcae19b2c6a4900df3cf827ab573ed0beac",
-                "reference": "1cc2bdcae19b2c6a4900df3cf827ab573ed0beac",
+                "url": "https://api.github.com/repos/humanmade/asset-loader/zipball/f91409a9a8fae5981a65e3017dbd58175b5bcac4",
+                "reference": "f91409a9a8fae5981a65e3017dbd58175b5bcac4",
                 "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "10up/wp_mock": "^0.4.2",
-                "humanmade/coding-standards": "^1.1.0",
-                "phpunit/phpunit": "^7.5"
+                "10up/wp_mock": "^1.1.0",
+                "automattic/vipwpcs": "^3.0",
+                "phpunit/phpunit": "^9.5",
+                "staabm/annotate-pull-request-from-checkstyle": "^1.8",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "type": "wordpress-plugin",
             "notification-url": "https://packagist.org/downloads/",
@@ -688,9 +648,9 @@
             "description": "Utilities to seamlessly consume Webpack-bundled assets in WordPress themes & plugins.",
             "support": {
                 "issues": "https://github.com/humanmade/asset-loader/issues",
-                "source": "https://github.com/humanmade/asset-loader/tree/v0.6.4"
+                "source": "https://github.com/humanmade/asset-loader/tree/v0.8.0"
             },
-            "time": "2023-12-05T15:10:30+00:00"
+            "time": "2026-02-20T18:39:50+00:00"
         },
         {
             "name": "humanmade/asset-manager-framework",
@@ -1764,16 +1724,16 @@
         },
         {
             "name": "pfefferle/wordpress-activitypub",
-            "version": "9.0.1",
+            "version": "9.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wordpress-activitypub.git",
-                "reference": "4aee8f92c26239a470f16a2117921aeac37f8762"
+                "reference": "280a7b795b4a6154262fcf8900f90f96f3ef6316"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/4aee8f92c26239a470f16a2117921aeac37f8762",
-                "reference": "4aee8f92c26239a470f16a2117921aeac37f8762",
+                "url": "https://api.github.com/repos/Automattic/wordpress-activitypub/zipball/280a7b795b4a6154262fcf8900f90f96f3ef6316",
+                "reference": "280a7b795b4a6154262fcf8900f90f96f3ef6316",
                 "shasum": ""
             },
             "require": {
@@ -1814,9 +1774,9 @@
             "description": "The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.",
             "support": {
                 "issues": "https://github.com/Automattic/wordpress-activitypub/issues",
-                "source": "https://github.com/Automattic/wordpress-activitypub/tree/9.0.1"
+                "source": "https://github.com/Automattic/wordpress-activitypub/tree/9.0.2"
             },
-            "time": "2026-06-15T13:12:54+00:00"
+            "time": "2026-06-29T08:21:15+00:00"
         },
         {
             "name": "stuttter/wp-user-signups",
@@ -2012,15 +1972,15 @@
         },
         {
             "name": "wp-plugin/altis-accelerate",
-            "version": "4.2.2",
+            "version": "4.3.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/altis-accelerate/",
-                "reference": "tags/4.2.2"
+                "reference": "tags/4.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.2.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/altis-accelerate.4.3.1.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2038,7 +1998,7 @@
                 "issues": "https://wordpress.org/support/plugin/altis-accelerate",
                 "source": "https://plugins.svn.wordpress.org/altis-accelerate"
             },
-            "time": "2026-06-11T18:00:46+00:00"
+            "time": "2026-06-26T14:45:41+00:00"
         },
         {
             "name": "wp-plugin/amazon-s3-and-cloudfront",
@@ -2166,15 +2126,15 @@
         },
         {
             "name": "wp-plugin/gutenberg",
-            "version": "23.3.2",
+            "version": "23.4.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/gutenberg/",
-                "reference": "tags/23.3.2"
+                "reference": "tags/23.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/gutenberg.23.3.2.zip"
+                "url": "https://downloads.wordpress.org/plugin/gutenberg.23.4.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2193,7 +2153,7 @@
                 "issues": "https://wordpress.org/support/plugin/gutenberg",
                 "source": "https://plugins.svn.wordpress.org/gutenberg"
             },
-            "time": "2026-06-04T14:35:51+00:00"
+            "time": "2026-06-17T08:51:03+00:00"
         },
         {
             "name": "wp-plugin/hello-ziggy",
@@ -2258,15 +2218,15 @@
         },
         {
             "name": "wp-plugin/ninja-forms",
-            "version": "3.14.6",
+            "version": "3.14.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ninja-forms/",
-                "reference": "tags/3.14.6"
+                "reference": "tags/3.14.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/ninja-forms.3.14.7.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2285,7 +2245,7 @@
                 "issues": "https://wordpress.org/support/plugin/ninja-forms",
                 "source": "https://plugins.svn.wordpress.org/ninja-forms"
             },
-            "time": "2026-06-08T14:06:53+00:00"
+            "time": "2026-06-22T14:45:51+00:00"
         },
         {
             "name": "wp-plugin/organize-series",
@@ -2444,15 +2404,15 @@
         },
         {
             "name": "wp-plugin/query-monitor",
-            "version": "4.0.6",
+            "version": "4.0.7",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/query-monitor/",
-                "reference": "tags/4.0.6"
+                "reference": "tags/4.0.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/query-monitor.4.0.6.zip"
+                "url": "https://downloads.wordpress.org/plugin/query-monitor.4.0.7.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2471,7 +2431,7 @@
                 "issues": "https://wordpress.org/support/plugin/query-monitor",
                 "source": "https://plugins.svn.wordpress.org/query-monitor"
             },
-            "time": "2026-04-11T11:56:17+00:00"
+            "time": "2026-06-20T20:20:53+00:00"
         },
         {
             "name": "wp-plugin/regenerate-thumbnails",
@@ -2626,15 +2586,15 @@
         },
         {
             "name": "wp-plugin/wp-mail-smtp",
-            "version": "4.8.0",
+            "version": "4.9.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-mail-smtp/",
-                "reference": "tags/4.8.0"
+                "reference": "tags/4.9.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.8.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-mail-smtp.4.9.0.zip"
             },
             "require": {
                 "composer/installers": "~1.0|~2.0"
@@ -2653,7 +2613,7 @@
                 "issues": "https://wordpress.org/support/plugin/wp-mail-smtp",
                 "source": "https://plugins.svn.wordpress.org/wp-mail-smtp"
             },
-            "time": "2026-04-16T15:16:32+00:00"
+            "time": "2026-06-25T08:56:20+00:00"
         },
         {
             "name": "wp-theme/museum-core",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -60,6 +60,7 @@
 	<exclude-pattern>wp-content/db.php</exclude-pattern>
 	<exclude-pattern>wp-content/uploads/*</exclude-pattern>
 	<exclude-pattern>index.php</exclude-pattern>
+	<exclude-pattern>wp-content/plugins/mcp-adapter</exclude-pattern>
 
 	<!-- Ignore Artbox -->
 	<exclude-pattern>wp-content/themes/artbox</exclude-pattern>

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.11.5",
+  "version": "1.11.6",
   "versionDescription": "Updates and patches should always be x.x.Y patch updates. WordPress updates or major feature additions (like new plugins or themes) should be x.Y.x minor updates. Major site updates should be Y.x.x major updates."
 }


### PR DESCRIPTION
# Dependency updates and housekeeping

Routine Composer and GitHub Actions dependency updates accumulated on `dev`, plus a small cleanup. No new plugins, themes, or major feature changes.

## What's new

- **ActivityPub** updated 8.3.0 → 9.2.1 — includes several federation security hardening fixes (escaping, permission checks, actor/object validation) and behavior improvements
- **Altis CMS** updated 26.0.7 → 27.0.3 — pulls in WordPress 7.0.2
- **Altis Browser Security** updated 2.2.0 → 2.2.1
- **Altis Accelerate** updated 4.1.3 → 4.3.3
- **Gutenberg** updated 23.2.2 → 23.7.0
- **LiteSpeed Cache** updated 7.8.1 → 7.9
- **Ninja Forms** updated 3.14.4 → 3.14.11
- **Patchstack** updated 2.3.6 → 2.3.7
- **Query Monitor** updated 4.0.6 → 4.0.7
- **WP Crontrol** updated 1.21.0 → 1.21.1
- **WP Mail SMTP** updated 4.8.0 → 4.9.0
- **Autoblue** updated 1.0.0 → 2.0.1
- **Asset Loader** updated v0.6.4 → v0.8.0
- **wp-coding-standards/wpcs** updated 3.3.0 → 3.4.1 — security fix (GHSA-3pwp-g2mj-5p3v)
- **pantheon-wp-coding-standards** updated 3.0.1 → 3.0.2 — enforces the wpcs security fix above
- **squizlabs/php_codesniffer** updated 3.13.5 → 3.13.6 — security fix (GHSA-hmqg-cxww-wqhq, shell command injection via crafted filenames in Gitblame/Hgblame/Svnblame reports)
- **IonBazan/composer-diff-action** (CI) updated v1 → v2
- Assorted dev-dependency and GitHub Actions bumps (`actions/checkout` 6→7, `actions/cache` 5→6, phpcsextra/phpcsutils/phpdoc-parser, vipwpcs)

## Housekeeping

- Gitignored `index.php.bak`, a stray backup artifact from `composer backup-files` that wasn't covered like its `wp-config.php.bak` counterpart
- Minor `phpcs.xml` exclude-pattern reordering